### PR TITLE
Fix typos in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ yarn build
 ## Usage
 
 You can run this either via `yarn`:
+
 ```
 yarn analyze:bat --debug --console two-fer ~/path/to/solution/folder
 ```
 
 Or directly via the provided shell script:
+
 ```
-./bin/analyze.sh two_fer ~/path/to/solution
+./bin/analyze.sh --debug --console two-fer ~/path/to/solution/folder
 ```
 
 Add the `--debug` and `--console` flags to get output in the terminal window.


### PR DESCRIPTION
Fixing a few issues in the README:

1. The slug in the `./bin/analyze.sh` example is incorrect
2. The path in the `./bin/analyze.sh` example should be pointing to the folder instead of the actual solution
3. The `--debug` and `--console` flags need to be in the command if people want to see the output in the terminal, so I think it's helpful to have them in the example