### PR TITLE
Fix Docker build and prepare step

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-test
 dist
 node_modules
 .git

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+production_node_modules
 dist
 yarn-error.log
 analysis.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.1
+
+Fixes the build and prepare step of the Docker-based image
+
+## 0.1.0
+
+:baby: initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ RUN adduser -D -g '' appuser
 WORKDIR /javascript-analyzer
 COPY . .
 
-# build
-RUN yarn install && yarn build && yarn install --prod
+# Install without arguments runs yarn prepublish
+RUN yarn install
+
+# Only install the node_modules we need
+RUN yarn install --production --modules-folder './production_node_modules'
 
 # Build a minimal and secured container
 FROM node:lts-alpine
@@ -19,7 +22,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /javascript-analyzer/bin /opt/analyzer/bin
 COPY --from=builder /javascript-analyzer/dist /opt/analyzer/dist
-COPY --from=builder /javascript-analyzer/node_modules /opt/analyzer/node_modules
+COPY --from=builder /javascript-analyzer/production_node_modules /opt/analyzer/node_modules
 USER appuser
 WORKDIR /opt/analyzer
 ENTRYPOINT ["/opt/analyzer/bin/analyze.sh"]

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
     "**/?(*.)+(spec|test).[jt]s?(x)"
   ],
   testPathIgnorePatterns: [
-    '/node_modules/',
+    '/(?:production_)?node_modules/',
     '.d.ts$',
     '<rootDir>/test/fixtures',
     '<rootDir>/test/helpers'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exercism/javascript-analyzer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Exercism analyzer for javascript",
   "repository": "https://github.com/exercism/javascript-analyzer",
   "author": "Derk-Jan Karrenbeld <derk-jan+github@karrenbeld.info>",


### PR DESCRIPTION
`yarn install` will install `devDependencies`

- additionally it runs `yarn prepublish` (because that's how it works)
- this in turn runs `yarn test`
- this in turn runs `yarn build` (what we want) and `jest` (to validate)

This means that the tests MUST be present when building the image. They are *not* copied over, so this is not an issues.

Additionally, this creates a new `production_node_modules` folder with the right flags set, so that the final image `node_modules` is extremely small.