### PR TITLE
resistor-color: Initial analyzer that only approves

### DIFF
--- a/src/analyzers/resistor-color/index.ts
+++ b/src/analyzers/resistor-color/index.ts
@@ -1,28 +1,19 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree"
-
-import { AnalyzerImpl } from "../AnalyzerImpl"
-
-import { extractExport } from "../utils/extract_export"
-import { extractMainMethod, MainMethod } from "../utils/extract_main_method"
-
-import { factory } from "../../comments/comment"
-import {
-  NO_METHOD,
-  NO_NAMED_EXPORT,
-  UNEXPECTED_SPLAT_ARGS,
-  NO_PARAMETER,
-} from "../../comments/shared"
-
-import { parameterName } from '../utils/extract_parameter'
-import { annotateType } from "../utils/type_annotations"
-import { isIdentifier } from "../utils/is_identifier";
-import { AstParser } from "../../parsers/AstParser";
-
+import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree";
 import { Program } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
-import { findTopLevelConstants } from "../utils/find_top_level_constants";
-import { isCallExpression } from "../utils/is_call_expression";
-import { isReturnBlockStatement } from "../utils/is_return_block_statement";
-import { isReturnStatementWithValue } from "../utils/is_return_statement_with_value";
+
+import { isReturnBlockStatement } from "~src/analyzers//utils/is_return_block_statement";
+import { isReturnStatementWithValue } from "~src/analyzers//utils/is_return_statement_with_value";
+import { AnalyzerImpl } from "~src/analyzers/AnalyzerImpl";
+import { extractExport } from "~src/analyzers/utils/extract_export";
+import { extractMainMethod, MainMethod } from "~src/analyzers/utils/extract_main_method";
+import { parameterName } from '~src/analyzers/utils/extract_parameter';
+import { findTopLevelConstants } from "~src/analyzers/utils/find_top_level_constants";
+import { isCallExpression } from "~src/analyzers/utils/is_call_expression";
+import { isIdentifier } from "~src/analyzers/utils/is_identifier";
+import { annotateType } from "~src/analyzers/utils/type_annotations";
+import { factory } from "~src/comments/comment";
+import { NO_METHOD, NO_NAMED_EXPORT, NO_PARAMETER, UNEXPECTED_SPLAT_ARGS } from "~src/comments/shared";
+import { AstParser } from "~src/parsers/AstParser";
 
 const TIP_EXPORT_INLINE = factory`
 Did you know that you can export functions, classes and constants directly
@@ -62,7 +53,7 @@ export class ResistorColorAnalyzer extends AnalyzerImpl {
   get mainConstant() {
     if (!this._mainConstant) {
       this._mainConstant = findTopLevelConstants(this.program, ['let', 'const', 'var']).find(
-        ({ declarations }) => declarations.find((declaration) => {
+        ({ declarations }) => !!declarations.find((declaration) => {
           return isIdentifier(declaration.id, 'COLORS')
         })
       ) || NOT_FOUND

--- a/src/analyzers/resistor-color/index.ts
+++ b/src/analyzers/resistor-color/index.ts
@@ -1,0 +1,300 @@
+import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree"
+
+import { AnalyzerImpl } from "../AnalyzerImpl"
+
+import { extractExport } from "../utils/extract_export"
+import { extractMainMethod, MainMethod } from "../utils/extract_main_method"
+
+import { factory } from "../../comments/comment"
+import {
+  NO_METHOD,
+  NO_NAMED_EXPORT,
+  UNEXPECTED_SPLAT_ARGS,
+  NO_PARAMETER,
+} from "../../comments/shared"
+
+import { parameterName } from '../utils/extract_parameter'
+import { annotateType } from "../utils/type_annotations"
+import { isIdentifier } from "../utils/is_identifier";
+import { AstParser } from "../../parsers/AstParser";
+
+import { Program } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
+import { findTopLevelConstants } from "../utils/find_top_level_constants";
+import { isCallExpression } from "../utils/is_call_expression";
+import { isReturnBlockStatement } from "../utils/is_return_block_statement";
+import { isReturnStatementWithValue } from "../utils/is_return_statement_with_value";
+
+const TIP_EXPORT_INLINE = factory`
+Did you know that you can export functions, classes and constants directly
+inline?
+`('javascript.resistor-color.export_inline')
+
+const Parser: AstParser = new AstParser(undefined, 1)
+
+const NOT_FOUND = {} as const
+
+export class ResistorColorAnalyzer extends AnalyzerImpl {
+
+  private program!: Program
+  private source!: string
+
+  private _mainMethod!: ReturnType<typeof extractMainMethod>
+  private _mainConstant!: ReturnType<typeof findTopLevelConstants>[0] | typeof NOT_FOUND
+  private _mainExports!: { function: ReturnType<typeof extractExport>, constant: ReturnType<typeof extractExport> }
+
+  get mainMethod() {
+    if (!this._mainMethod) {
+      this._mainMethod = extractMainMethod(this.program, 'colorCode')
+    }
+    return this._mainMethod
+  }
+
+  get mainExports() {
+    if (!this._mainExports) {
+      this._mainExports = {
+        function: extractExport(this.program, 'colorCode'),
+        constant: extractExport(this.program, 'COLORS')
+      }
+    }
+    return this._mainExports
+  }
+
+  get mainConstant() {
+    if (!this._mainConstant) {
+      this._mainConstant = findTopLevelConstants(this.program, ['let', 'const', 'var']).find(
+        ({ declarations }) => declarations.find((declaration) => {
+          return isIdentifier(declaration.id, 'COLORS')
+        })
+      ) || NOT_FOUND
+    }
+
+    return this._mainConstant
+  }
+
+  public async execute(input: Input): Promise<void> {
+    const [parsed] = await Parser.parse(input)
+
+    this.program = parsed.program
+    this.source = parsed.source
+
+    // Firstly we want to check that the structure of this solution is correct
+    // and that there is nothing structural stopping it from passing the tests
+    this.checkStructure()
+
+    // Now we want to ensure that the method signature is sane and that it has
+    // valid arguments
+    this.checkSignature()
+
+    // There are a handful optimal solutions for resistor-color which needs no
+    // comments and can just be approved. If we have it, then let's just
+    // acknowledge it and get out of here.
+    this.checkForOptimalSolutions()
+
+    // The solution is automatically referred to the mentor if it reaches this
+  }
+
+  private checkStructure() {
+    const method = this.mainMethod
+    const { function: [functionDeclaration,], constant: [constantDeclaration, ] } = this.mainExports
+
+    // First we check that there is a two-fer function and that this function
+    // is exported.
+    if (!method) {
+      this.comment(NO_METHOD({ method_name: 'colorCode' }))
+    }
+
+    if (!functionDeclaration) {
+      this.comment(NO_NAMED_EXPORT({ export_name: 'colorCode' }))
+    }
+
+    if (!constantDeclaration) {
+      this.comment(NO_NAMED_EXPORT({ export_name: 'COLORS' }))
+    }
+
+    if (this.hasCommentary) {
+      this.disapprove()
+    }
+  }
+
+  private checkSignature() {
+    const method: MainMethod = this.mainMethod!
+
+    // If there is no parameter or it doesn't have a default value,
+    // then this solution won't pass the tests.
+    if (method.params.length === 0) {
+      this.disapprove(NO_PARAMETER({ function_name: method.id!.name }))
+    }
+
+    const firstParameter = method.params[0]
+
+    // If they provide a splat, the tests can pass but we should suggest they
+    // use a real parameter.
+    if (firstParameter.type === AST_NODE_TYPES.RestElement) {
+      const splatArgName = parameterName(firstParameter)
+      const splatArgType = annotateType(firstParameter.typeAnnotation)
+
+      this.disapprove(UNEXPECTED_SPLAT_ARGS({ 'splat_arg_name': splatArgName, parameter_type: splatArgType }))
+    }
+  }
+
+  private checkForOptimalSolutions() {
+    // The optional solution looks like this:
+    //
+    // export const COLORS = ['...', '...']
+    // export function colorCode(color) {
+    //   return COLORS.indexOf(color)
+    // }
+    //
+    // The COLORS constant must be an Array and there must be a single call to
+    // indexOf. Additionally, the function can not have a default argument, or
+    // any other syntax, such as conditionals, re-assignment, and so forth.
+    //
+    // Other solutions might be approved but this
+    // is the only one that we would approve without comment.
+    //
+
+    if (
+         // !this.isArgumentOptimal()
+      !this.isOneCallSolution()
+      // || !this.isUsingArrayColors()
+      // || !this.isUsingIndexOf()
+    ) {
+      // continue analyzing
+      this.logger.log('~> Solution is not optimal')
+      return
+    }
+
+    this.checkForTips()
+    this.approve()
+  }
+
+  private checkForTips() {
+    if (!this.hasInlineExport()) {
+      this.comment(TIP_EXPORT_INLINE())
+    }
+  }
+
+  private isOneCallSolution() {
+    // Maximum body count may be 3 (3 - 1 + 1)
+    //
+    // 1: export function colorCode(color) {
+    // 2:  return ...
+    // 3: }
+    //
+    // but can also be less 1 (1 - 1 + 1)
+    //
+    // 1: export const colorCode = (color) => ...
+    //
+    const method: MainMethod = this.mainMethod!
+    const body = method.body!
+
+    // This trick actually looks to the inner exppresion instead of the entire
+    // function in order to allow for comments inside the body.
+    const { loc: { start: { line: lineStart }, end: { line: lineEnd } } } =
+      isReturnBlockStatement(body)
+      ? body.body[0]
+      : method
+
+    this.logger.log(`=> Body consists of ${lineEnd - lineStart + 1} lines and is a ${method.type}.`)
+
+    if ((lineEnd - lineStart + 1) > 3) {
+      return false
+    }
+
+    // There can only be a single call to COLORS.indexOf and there may not be
+    // an other tokens, whatsoever. The following checks are only testing the
+    // optimal variations.
+
+    // function colorCode(color) { return COLORS.indexOf(color) }
+    //
+    if (method.type === AST_NODE_TYPES.FunctionDeclaration) {
+      this.logger.log(`=> The Function Declaration has ${method.params.length} argument(s)`)
+
+      if (method.params.length !== 1) {
+        return false
+      }
+
+      const functionParameter = method.params[0]
+      const callExpression = method.body
+        && isReturnBlockStatement(method.body)
+        && isReturnStatementWithValue(method.body.body[0])
+        && isCallExpression(method.body.body[0].argument, 'COLORS', 'indexOf')
+        && method.body.body[0].argument
+
+      return isIdentifier(functionParameter)
+        && callExpression
+        && isIdentifier(callExpression.arguments[0], functionParameter.name)
+    }
+
+    // const colorCode = (color) => COLORS.indexOf(color)
+    // const colorCode = (color) => { return COLORS.indexOf(color) }
+    //
+    if (method.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+      this.logger.log(`=> The Arrow Function Expression has ${method.params.length} argument(s)`)
+
+      if (method.params.length !== 1) {
+        return false
+      }
+
+      const functionParameter = method.params[0]
+
+      // First test/option is the implicit return
+      // Second test/option is the explicit return
+      //
+      const callExpression = (isCallExpression(body, 'COLORS', 'indexOf') && body)
+        || (
+          isReturnBlockStatement(body)
+          && isReturnStatementWithValue(body.body[0])
+          && isCallExpression(body.body[0].argument, 'COLORS', 'indexOf')
+          && body.body[0].argument
+        )
+
+      return isIdentifier(functionParameter)
+        && callExpression
+        && isIdentifier(callExpression.arguments[0], functionParameter.name)
+    }
+
+    // const colorCode = function (color) { return COLORS.indexOf(color) }
+    //
+    if (method.type === AST_NODE_TYPES.FunctionExpression) {
+      this.logger.log(`=> The Function Expression has ${method.params.length} argument(s)`)
+
+      if (method.params.length > 1) {
+        return false
+      }
+
+      const functionParameter = method.params[0]
+      const callExpression = body
+        && isReturnBlockStatement(body)
+        && isReturnStatementWithValue(body.body[0])
+        && isCallExpression(body.body[0].argument, 'COLORS', 'indexOf')
+        && body.body[0].argument
+
+      return isIdentifier(functionParameter)
+        && callExpression
+        && isIdentifier(callExpression.arguments[0], functionParameter.name)
+    }
+
+    // Should _never_ happen
+    this.logger.log(`=> The body failed all the stuctural tests. It's a ${method!.type}.`)
+    // Bail out
+    this.redirect()
+  }
+
+  private hasInlineExport() {
+    // Additionally make sure the export is inline by checking if it doesn't
+    // have any specifiers:
+    //
+    // export function value
+    // => no specififers
+    //
+    // export { value }
+    // => yes specififers
+    //
+    return this.mainExports.function[0]!.specifiers
+      && this.mainExports.function[0]!.specifiers.length === 0
+      && this.mainExports.constant[0]!.specifiers
+      && this.mainExports.constant[0]!.specifiers.length === 0
+  }
+}
+

--- a/src/analyzers/resistor-color/index.ts
+++ b/src/analyzers/resistor-color/index.ts
@@ -119,7 +119,7 @@ export class ResistorColorAnalyzer extends AnalyzerImpl {
   private checkSignature() {
     const method: MainMethod = this.mainMethod!
 
-    // If there is no parameter or it doesn't have a default value,
+    // If there is no parameter
     // then this solution won't pass the tests.
     if (method.params.length === 0) {
       this.disapprove(NO_PARAMETER({ function_name: method.id!.name }))

--- a/src/analyzers/utils/find_top_level_constants.ts
+++ b/src/analyzers/utils/find_top_level_constants.ts
@@ -7,8 +7,8 @@ const CONSTANT_MODIFIERS = [
   AST_NODE_TYPES.ExportNamedDeclaration
 ]
 
-function isTopLevelConstant(this: Traverser, node: Node): boolean {
-  if (node.type !== AST_NODE_TYPES.VariableDeclaration || node.kind !== 'const') {
+function isTopLevelConstant(this: Traverser, node: Node, kinds: VariableDeclaration["kind"][] = ['const']): boolean {
+  if (node.type !== AST_NODE_TYPES.VariableDeclaration || !kinds.includes(node.kind)) {
     if (!CONSTANT_MODIFIERS.indexOf(node.type)) {
       this.skip() // doesn't traverse this node any further
     }
@@ -24,9 +24,9 @@ function isTopLevelConstant(this: Traverser, node: Node): boolean {
  * @param root the top-level
  * @returns Node[]
  */
-export function findTopLevelConstants(root: Node) {
+export function findTopLevelConstants(root: Node, kinds: VariableDeclaration["kind"][] = ['const']) {
   return findAll(
     root,
-    isTopLevelConstant
+    function(node) { return isTopLevelConstant.apply(this, [node, kinds]) }
   ) as VariableDeclaration[]
 }

--- a/src/analyzers/utils/is_call_expression.ts
+++ b/src/analyzers/utils/is_call_expression.ts
@@ -1,8 +1,15 @@
 import { Node, CallExpression } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
 import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree";
-import { isMemberExpression } from "./is_member_expression";
+import { isMemberExpression, SpecificObject, SpecificProperty } from "./is_member_expression";
 
-export function isCallExpression(node: Node, object?: string, property?: string): node is CallExpression {
+type SpecificObjectCall<O> = CallExpression & { callee: SpecificObject<O> }
+type SpecificPropertyCall<P> = CallExpression & { callee: SpecificProperty<P> }
+type SpecificObjectPropertyCall<O, P> = SpecificObjectCall<O> & SpecificPropertyCall<P>
+
+export function isCallExpression<O extends string, P extends string>(node: Node, object: O, property: P): node is SpecificObjectPropertyCall<O, P>
+export function isCallExpression<O extends string>(node: Node, object: O, property?: undefined): node is SpecificObjectCall<O>
+export function isCallExpression<P extends string>(node: Node, object: undefined, property: P): node is SpecificPropertyCall<P>
+export function isCallExpression<O extends string | undefined, P extends string | undefined>(node: Node, object?: O, property?: P): node is CallExpression {
   return node.type === AST_NODE_TYPES.CallExpression
-    && isMemberExpression(node.callee, object, property)
+    && isMemberExpression<any, any>(node.callee, object, property)
 }

--- a/src/analyzers/utils/is_member_expression.ts
+++ b/src/analyzers/utils/is_member_expression.ts
@@ -1,9 +1,16 @@
-import { Node, MemberExpression } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
+import { Node, MemberExpression, Identifier, Literal } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
 import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree";
 import { isIdentifier } from "./is_identifier";
 import { isLiteral } from "./is_literal";
 
-export function isMemberExpression(node: Node, object?: string, property?: string): node is MemberExpression {
+export type SpecificObject<O> = MemberExpression & { object: Identifier & { name: O } }
+export type SpecificProperty<P> = MemberExpression & { property: (Identifier & { name: P }) | (Literal & { value: P }) }
+export type SpecificObjectProperty<O, P> = SpecificObject<O> & SpecificProperty<P>
+
+export function isMemberExpression<O extends string, P extends string>(node: Node, object: O, property: P): node is SpecificObjectProperty<O, P>
+export function isMemberExpression<O extends string>(node: Node, object: O, property?: undefined): node is SpecificObject<O>
+export function isMemberExpression<P extends string>(node: Node, object: undefined, property: P): node is SpecificProperty<P>
+export function isMemberExpression<O extends string | undefined, P extends string | undefined>(node: Node, object?: O, property?: P): node is MemberExpression {
   return node.type === AST_NODE_TYPES.MemberExpression
     && (object === undefined || isIdentifier(node.object, object))
     && (property === undefined || isIdentifier(node.property, property) || isLiteral(node.property, property))

--- a/src/analyzers/utils/is_return_block_statement.ts
+++ b/src/analyzers/utils/is_return_block_statement.ts
@@ -1,0 +1,10 @@
+import { Node, ReturnStatement, BlockStatement } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
+import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree";
+
+type BlockWithReturnStatement = BlockStatement & { body: [ReturnStatement] }
+
+export function isReturnBlockStatement(node: Node): node is BlockWithReturnStatement {
+  return node.type === AST_NODE_TYPES.BlockStatement
+    && node.body.length === 1
+    && node.body[0].type === AST_NODE_TYPES.ReturnStatement
+}

--- a/src/analyzers/utils/is_return_statement_with_value.ts
+++ b/src/analyzers/utils/is_return_statement_with_value.ts
@@ -1,0 +1,12 @@
+import { Node, ReturnStatement } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
+import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree";
+
+type ReturnStatementWithValue = ReturnStatement & { argument: NonNullable<ReturnStatement['argument']> }
+
+/**
+ * Checks if the node is `return ...` and not `return;`
+ */
+export function isReturnStatementWithValue(node: Node): node is ReturnStatementWithValue {
+  return node.type === AST_NODE_TYPES.ReturnStatement
+    && node.argument !== null
+}

--- a/test/analyzers/resistor-color/__snapshots__/snapshot.ts.snap
+++ b/test/analyzers/resistor-color/__snapshots__/snapshot.ts.snap
@@ -1,0 +1,421 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/0's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/1's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/2's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/12's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/13's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/14's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/16's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/17's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/18's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/20's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/100's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/101's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/102's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/105's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/106's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/107's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/110's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/113's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/115's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/117's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/122's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/123's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/127's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/131's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/132's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/134's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/135's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/137's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/138's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/142's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/149's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/150's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/151's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/158's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/161's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/163's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/164's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/165's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/168's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/171's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/172's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/173's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/174's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/175's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/179's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/180's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/182's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/184's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/186's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/187's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/189's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/191's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/192's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/196's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/197's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/199's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/206's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/209's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/211's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to approve as optimal matches resistor-color/212's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [],
+  "status": "approve_as_optimal",
+}
+`;

--- a/test/analyzers/resistor-color/smoke.ts
+++ b/test/analyzers/resistor-color/smoke.ts
@@ -1,0 +1,21 @@
+import { ResistorColorAnalyzer } from '~src/analyzers/resistor-color'
+import { makeAnalyze } from '~test/helpers/smoke'
+
+const analyze = makeAnalyze(() => new ResistorColorAnalyzer())
+
+describe('When running analysis on resistor-color', () => {
+  it('can approve as optimal', async () => {
+
+    const solutionContent = `
+    export const COLORS = ['...', '...']
+    export function colorCode(color) {
+      return COLORS.indexOf(color)
+    }
+    `.trim()
+
+    const output = await analyze(solutionContent)
+
+    expect(output.status).toBe('approve_as_optimal');
+    expect(output.comments.length).toBe(0);
+  })
+})

--- a/test/analyzers/resistor-color/snapshot.ts
+++ b/test/analyzers/resistor-color/snapshot.ts
@@ -1,0 +1,20 @@
+import { ResistorColorAnalyzer } from '~src/analyzers/resistor-color'
+import { makeTestGenerator } from '~test/helpers/snapshot'
+
+const snapshotTestsGenerator = makeTestGenerator(
+  'resistor-color', () => new ResistorColorAnalyzer()
+)
+
+describe('When running analysis on two-fer fixtures', () => {
+  snapshotTestsGenerator('approve_as_optimal', [
+    0, 1, 100, 101, 102, 105, 106, 107, 110, 113,
+    115, 117, 12, 122, 123, 127, 13, 131, 132, 134,
+    135, 137, 138, 14, 142, 149, 150, 151, 158, 16,
+    161, 163, 164, 165, 168, 17, 171, 172, 173, 174,
+    175, 179, 18, 180, 182, 184, 186, 187, 189, 191,
+    192, 196, 197, 199, 2, 20, 206, 209, 211, 212
+  ])
+  snapshotTestsGenerator('approve_with_comment', [])
+  snapshotTestsGenerator('disapprove_with_comment', [])
+  snapshotTestsGenerator('refer_to_mentor', [])
+})


### PR DESCRIPTION
This adds the initial analyzer for `resistor-color`. Since the current iteration of the automated mentoring only works with instant approvals, we only `approve_as_optimal` here. The rest of the code can be written subsequently.

This also starts having better type guards, so that the typings of the helper utils are correct.

cc @zeckdude build on top of this if you'd like.

🚨 I will merge this during the weekend so we can get it up and running, unless there are comments or complaints. Prefer making subsequent edits later in other PRs.

## Raw

```json
{
  "toolRuntime": "960ms",
  "approve_as_optimal": {
    "count": 218,
    "comments": {
      "unique": [],
      "unique_templates": []
    },
    "runtimes": {
      "total": 117008872701,
      "average": 536737948,
      "median": 552378400
    }
  },
  "refer_to_mentor": {
    "count": 191,
    "comments": {
      "unique": [],
      "unique_templates": []
    },
    "runtimes": {
      "total": 104776207094,
      "average": 548566529,
      "median": 554233600
    }
  },
  "approve_with_comment": {
    "count": 47,
    "comments": {
      "unique": [
        "Did you know that you can export functions, classes and constants directly\ninline?"
      ],
      "unique_templates": [
        "Did you know that you can export functions, classes and constants directly\ninline?"
      ]
    },
    "runtimes": {
      "total": 24795423398,
      "average": 527562199,
      "median": 494847899
    }
  },
  "disapprove_with_comment": {
    "count": 42,
    "comments": {
      "unique": [
        "No method called `colorCode`. The tests won't pass without it.",
        "No [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) called `colorCode`.\nThe tests won't pass without it.\n\nDid you forget adding: `export colorCode`?",
        "No [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) called `COLORS`.\nThe tests won't pass without it.\n\nDid you
forget adding: `export COLORS`?"
      ],
      "unique_templates": [
        "No method called `%<method_name>s`. The tests won't pass without it.",
        "No [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) called `%<export_name>s`.\nThe tests won't pass without it.\n\nDid you forget adding: `export %<export_name>s`?"
      ]
    },
    "runtimes": {
      "total": 24253681500,
      "average": 577468607,
      "median": 592001200
    }
  }
}
```

## Statistics

|               Status | Count | Comments | Unique |    Avg | Median |   Total |
| --------------------:| -----:| --------:| ------:| ------:|-------:|--------:|
|    Approve (optimal) |   218 |        0 |      0 |  536ms |  552ms |     11s |
|    Approve (comment) |    47 |        1 |      1 |  527ms |  494ms |      2s |
| Disapprove (comment) |    42 |        3 |      2 |  577ms |  592ms |      2s |
|      Refer to mentor |   191 |        0 |      0 |  548ms |  554ms |     10s |
|                Total |   498 |        4 |      3 |  543ms |  555ms |     27s |