### PR TITLE
Cleanup imports with module alias

### DIFF
--- a/bin/analyze.bat
+++ b/bin/analyze.bat
@@ -1,4 +1,4 @@
 @REM Usage:
 @REM ./bin/analyze.bat two-fer ~/test/
 
-node -r esm ./dist/analyze.js %*
+node -r esm -r module-alias/register ./dist/analyze.js %*

--- a/bin/analyze.sh
+++ b/bin/analyze.sh
@@ -3,4 +3,4 @@
 # Usage:
 # ./bin/analyze.sh two-fer ~/folder/to/solution
 
-node -r esm ./dist/analyze.js "$@"
+node -r esm -r module-alias/register ./dist/analyze.js "$@"

--- a/bin/batch.bat
+++ b/bin/batch.bat
@@ -1,4 +1,4 @@
 @REM Usage:
 @REM ./bin/batch.bat two-fer
 
-node -r esm ./dist/batch.js %*
+node -r esm -r module-alias/register ./dist/batch.js %*

--- a/bin/batch.sh
+++ b/bin/batch.sh
@@ -3,4 +3,4 @@
 # Usage:
 # ./bin/batch.sh two-fer
 
-node -r esm ./dist/batch.js "$@"
+node -r esm -r module-alias/register ./dist/batch.js "$@"

--- a/bin/stats.bat
+++ b/bin/stats.bat
@@ -1,4 +1,4 @@
 @REM Usage:
 @REM ./bin/stats.bat two-fer
 
-node -r esm ./dist/stats.js %*
+node -r esm -r module-alias/register ./dist/stats.js %*

--- a/bin/stats.sh
+++ b/bin/stats.sh
@@ -3,4 +3,4 @@
 # Usage:
 # ./bin/stats.sh two-fer
 
-node -r esm ./dist/stats.js "$@"
+node -r esm -r module-alias/register ./dist/stats.js "$@"

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -1,0 +1,43 @@
+# Imports
+
+This project uses 2 TypeScript projects:
+
+- `src`: the source code for the binary execution
+- `test`: the tests for this source code
+
+Because relative imports can get unwieldy quickly, both projects have defined
+`paths` in their `tsconfig.json`:
+
+- `~src` points to the root of `src` (both projects can access this)
+- `~test` points to the root of `test` (only `test` can access this)
+
+## Configuration
+
+### Jest
+
+Because `.babelrc` does not automatically pick-up these rules, and `jest`
+supports this out of the box, the `jest.config.js` has the `moduleNameMapper`
+set up to be exactly like the paths above.
+
+### Production (compiled typescript)
+
+Because compilation via `tsc` does not rewrite paths (which, according to the
+`tsc` developer team is because that is a _loader_'s task), `module-alias` has
+also been set-up to rewrite these paths:
+
+- `~src` points to the root of `dist`
+
+## Development
+
+When developing for this repository, use `~src/path/to/file` whenever you need
+a module from that project and `~test/path/to/file` when you're in the test
+project. This also allows you to have the same module name in both projects.
+
+The only exception is loading a dependency that is a sibling or a direct child.
+For example:
+
+`~src/comments/shared.ts` defines shared comment factories. It loads the factory
+from its sibling `./comment.ts`. This is fine, because it's likely that they'll
+be moved in unison if they ever are.
+
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,10 @@ module.exports = {
   projects: [
     '<rootDir>'
   ],
+  moduleNameMapper: {
+    '^~src/(.*)$': '<rootDir>/src/$1',
+    '^~test/(.*)$': '<rootDir>/test/$1'
+  },
   testMatch: [
     "**/__tests__/**/*.[jt]s?(x)",
     "**/test/**/*.[jt]s?(x)",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
     "@typescript-eslint/parser": "^1.9.0",
     "@typescript-eslint/typescript-estree": "^1.9.0",
     "esm": "^3.2.25",
+    "module-alias": "^2.2.0",
     "yargs": "^13.2.4"
+  },
+  "_moduleAliases": {
+    "~src": "dist",
+    "~test": "test"
   }
 }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,6 +1,6 @@
-import { Bootstrap } from './utils/bootstrap'
-import { find } from './analyzers/Autoload'
-import { run } from './utils/runner'
+import { Bootstrap } from '~src/utils/bootstrap'
+import { find } from '~src/analyzers/Autoload'
+import { run } from '~src/utils/runner'
 
 // The bootstrap call uses the arguments passed to the process to figure out
 // which exercise to target, where the input lives (directory input) and what

--- a/src/analyzers/AnalyzerImpl.ts
+++ b/src/analyzers/AnalyzerImpl.ts
@@ -1,7 +1,6 @@
-import { getProcessLogger as getLogger, Logger } from '../utils/logger'
+import { getProcessLogger as getLogger, Logger } from '~src/utils/logger'
 
-import { AnalyzerOutput } from '../output/AnalyzerOutput';
-import { ParsedSource, AstParser } from '../parsers/AstParser';
+import { AnalyzerOutput } from '~src/output/AnalyzerOutput';
 
 class EarlyFinalization extends Error {
   constructor() {

--- a/src/analyzers/Autoload.ts
+++ b/src/analyzers/Autoload.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import { getProcessLogger } from '../utils/logger'
+import { getProcessLogger } from '~src/utils/logger'
 
 type AnalyzerConstructor = new () => Analyzer
 

--- a/src/analyzers/gigasecond/index.ts
+++ b/src/analyzers/gigasecond/index.ts
@@ -86,7 +86,7 @@ export class GigasecondAnalyzer extends AnalyzerImpl {
     return this._mainParameter
   }
 
-  public async execute(input: Input): Promise<void> {
+  protected async execute(input: Input): Promise<void> {
     const [parsed] = await GigasecondAnalyzer.Parser.parse(input)
 
     this.program = parsed.program

--- a/src/analyzers/two-fer/index.ts
+++ b/src/analyzers/two-fer/index.ts
@@ -1,40 +1,23 @@
-import {
-  ConditionalExpression,
-  IfStatement,
-  LogicalExpression,
-  Program,
-  TemplateLiteral,
-  Parameter
-} from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree"
-import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree"
+import { AST_NODE_TYPES } from "@typescript-eslint/typescript-estree";
+import { ConditionalExpression, IfStatement, LogicalExpression, Parameter, Program, TemplateLiteral } from "@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree";
 
-import { AnalyzerImpl } from "../AnalyzerImpl"
-
-import { extractAll } from "../utils/extract_all"
-import { extractExport } from "../utils/extract_export"
-import { extractFirst } from "../utils/extract_first"
-import { extractMainMethod, MainMethod } from "../utils/extract_main_method"
-
-import { factory } from "../../comments/comment"
-import {
-  NO_METHOD,
-  NO_NAMED_EXPORT,
-  UNEXPECTED_SPLAT_ARGS,
-  PREFER_TEMPLATED_STRINGS,
-  PREFER_STRICT_EQUALITY,
-  NO_PARAMETER,
-} from "../../comments/shared"
-
-import { parameterName } from '../utils/extract_parameter'
-import { annotateType } from "../utils/type_annotations"
-import { isAssignmentPattern } from "../utils/is_assignment_pattern";
-import { isBinaryExpression } from "../utils/is_binary_expression";
-import { isIdentifier } from "../utils/is_identifier";
-import { isLiteral } from "../utils/is_literal";
-import { isTemplateLiteral } from "../utils/is_template_literal";
-import { isUnaryExpression } from "../utils/is_unary_expression";
-import { isLogicalExpression } from "../utils/is_logical_expression";
-import { AstParser } from "../../parsers/AstParser";
+import { AnalyzerImpl } from "~src/analyzers/AnalyzerImpl";
+import { extractAll } from "~src/analyzers/utils/extract_all";
+import { extractExport } from "~src/analyzers/utils/extract_export";
+import { extractFirst } from "~src/analyzers/utils/extract_first";
+import { extractMainMethod, MainMethod } from "~src/analyzers/utils/extract_main_method";
+import { parameterName } from '~src/analyzers/utils/extract_parameter';
+import { isAssignmentPattern } from "~src/analyzers/utils/is_assignment_pattern";
+import { isBinaryExpression } from "~src/analyzers/utils/is_binary_expression";
+import { isIdentifier } from "~src/analyzers/utils/is_identifier";
+import { isLiteral } from "~src/analyzers/utils/is_literal";
+import { isLogicalExpression } from "~src/analyzers/utils/is_logical_expression";
+import { isTemplateLiteral } from "~src/analyzers/utils/is_template_literal";
+import { isUnaryExpression } from "~src/analyzers/utils/is_unary_expression";
+import { annotateType } from "~src/analyzers/utils/type_annotations";
+import { factory } from "~src/comments/comment";
+import { NO_METHOD, NO_NAMED_EXPORT, NO_PARAMETER, PREFER_STRICT_EQUALITY, PREFER_TEMPLATED_STRINGS, UNEXPECTED_SPLAT_ARGS } from "~src/comments/shared";
+import { AstParser } from "~src/parsers/AstParser";
 
 const OPTIMISE_DEFAULT_VALUE = factory<'parameter'>`
 You currently use a conditional to branch in case there is no value passed into
@@ -93,7 +76,7 @@ export class TwoFerAnalyzer extends AnalyzerImpl {
     return this._mainParameter
   }
 
-  public async execute(input: Input): Promise<void> {
+  protected async execute(input: Input): Promise<void> {
     const [parsed] = await Parser.parse(input)
 
     this.program = parsed.program

--- a/src/input/DirectoryInput.ts
+++ b/src/input/DirectoryInput.ts
@@ -1,7 +1,7 @@
-import { readDir } from "../utils/fs";
+import { readDir } from "~src/utils/fs";
 import { FileInput } from "./FileInput";
 
-import path from 'path'
+import nodePath from 'path'
 
 const EXTENSIONS = /\.(jsx?|tsx?|mjs)$/
 const TEST_FILES = /\.spec|test\./
@@ -15,7 +15,7 @@ export class DirectoryInput implements Input {
 
     const candidates = findCandidates(files, n, `${this.exerciseSlug}.js`)
     const fileSources = await Promise.all(
-      candidates.map(candidate => new FileInput(path.join(this.path, candidate)).read().then(([source]) => source))
+      candidates.map(candidate => new FileInput(nodePath.join(this.path, candidate)).read().then(([source]) => source))
     )
 
     return fileSources

--- a/src/input/FileInput.ts
+++ b/src/input/FileInput.ts
@@ -1,4 +1,4 @@
-import { readFile } from "../utils/fs";
+import { readFile } from "~src/utils/fs";
 
 export class FileInput implements Input {
   constructor(private readonly path: string) {}

--- a/src/output/processor/FileOutput.ts
+++ b/src/output/processor/FileOutput.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import { getProcessLogger } from '../../utils/logger'
+import { getProcessLogger } from '~src/utils/logger'
 
 type FileOutputOptions = Pick<ExecutionOptions, 'output' | 'inputDir'>
 

--- a/src/output/processor/LogOutput.ts
+++ b/src/output/processor/LogOutput.ts
@@ -1,4 +1,4 @@
-import { getProcessLogger } from '../../utils/logger'
+import { getProcessLogger } from '~src/utils/logger'
 
 export const LogOutput: OutputProcessor = async (previous: Promise<string>): Promise<string> => {
   const output = await previous

--- a/src/parsers/AstParser.ts
+++ b/src/parsers/AstParser.ts
@@ -1,5 +1,5 @@
 import { parse as parseToTree, TSESTree, TSESTreeOptions } from "@typescript-eslint/typescript-estree";
-import { getProcessLogger } from "../utils/logger";
+import { getProcessLogger } from "~src/utils/logger";
 
 type Program = TSESTree.Program
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,11 +1,12 @@
 
-import path from 'path'
-
-import { Bootstrap } from './utils/bootstrap'
-import { readDir } from './utils/fs';
-import { DirectoryInput } from './input/DirectoryInput'
-import { AstParser } from './parsers/AstParser';
 import { Node } from '@typescript-eslint/typescript-estree/dist/ts-estree/ts-estree';
+
+import path from 'path';
+
+import { DirectoryInput } from '~src/input/DirectoryInput';
+import { AstParser } from '~src/parsers/AstParser';
+import { Bootstrap } from '~src/utils/bootstrap';
+import { readDir } from '~src/utils/fs';
 
 // The bootstrap call uses the arguments passed to the process to figure out
 // which exercise to target, where the input lives (directory input) and what

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "composite": true,
   "extends": "../tsconfig.json",
-  "outDir": "./",
-  "include": [
-    "./"
-	]
+  "compilerOptions": {
+    "outDir": "../dist",
+    "baseUrl": "./",
+    "paths": {
+      "~src/*": ["./*"],
+    }
+  },
+  "include": ["./"],
+  "exclude": []
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -29,24 +29,6 @@ function fatal(this: Logger, buffer: LoggerInput, status = 1): never {
 
 function noop(_: LoggerInput) {}
 
-const LIVE_BINDING: { current: Logger | null } = { current: null }
-
-/**
- * Set the 'global' logger
- * @param logger
- * @returns the global logger
- */
-export function setProcessLogger(logger: Readonly<Logger>) {
-  return LIVE_BINDING.current = logger
-}
-
-/**
- * Get the 'global' logger
- */
-export function getProcessLogger(): Logger {
-  return LIVE_BINDING.current!
-}
-
 export interface Logger {
   error: typeof error
   fatal: typeof fatal
@@ -62,4 +44,23 @@ export class Logger {
       log: debug ? (console ? global.console.log : log) : noop,
     })
   }
+}
+
+const NOOP_LOGGER = new Logger({ debug: false, console: false })
+const LIVE_BINDING: { current: Logger | null } = { current: NOOP_LOGGER }
+
+/**
+ * Set the 'global' logger
+ * @param logger
+ * @returns the global logger
+ */
+export function setProcessLogger(logger: Readonly<Logger>) {
+  return LIVE_BINDING.current = logger
+}
+
+/**
+ * Get the 'global' logger
+ */
+export function getProcessLogger(): Logger {
+  return LIVE_BINDING.current || NOOP_LOGGER
 }

--- a/test/helpers/bootstrap.ts
+++ b/test/helpers/bootstrap.ts
@@ -1,7 +1,7 @@
-import { ExecutionOptionsImpl } from "../../src/utils/execution_options";
-import { ExerciseImpl } from "../../src/ExerciseImpl";
-import { BootstrapResult } from "../../src/utils/bootstrap";
-import { setProcessLogger, Logger } from "../../src/utils/logger";
+import { ExecutionOptionsImpl } from "~src/utils/execution_options";
+import { ExerciseImpl } from "~src/ExerciseImpl";
+import { BootstrapResult } from "~src/utils/bootstrap";
+import { setProcessLogger, Logger } from "~src/utils/logger";
 
 export function bootstrap({ exercise, ...overrides }: { exercise: string } & Partial<ExecutionOptions>): Omit<BootstrapResult, 'input'> {
   const options = new ExecutionOptionsImpl({

--- a/test/helpers/input/FixtureInput.ts
+++ b/test/helpers/input/FixtureInput.ts
@@ -1,0 +1,15 @@
+import { DirectoryInput } from "~src/input/DirectoryInput";
+
+import nodePath from 'path'
+
+export class FixtureInput extends DirectoryInput {
+  /**
+   * Create a new fixture reference
+   *
+   * @param slug the slug of the exercise
+   * @param num the exercise index
+   */
+  constructor(slug: string, private readonly num: number) {
+    super(nodePath.join(__dirname, '..', '..', 'fixtures', slug, num.toString()), slug)
+  }
+}

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -1,9 +1,9 @@
-import { TwoFerAnalyzer } from '../src/analyzers/two-fer'
-import { run } from '../src/utils/runner'
-import { find } from '../src/analyzers/Autoload'
+import { TwoFerAnalyzer } from '~src/analyzers/two-fer'
+import { run } from '~src/utils/runner'
+import { find } from '~src/analyzers/Autoload'
 
-import { bootstrap } from './helpers/bootstrap'
-import { InlineInput } from './helpers/input/InlineInput'
+import { bootstrap } from '~test/helpers/bootstrap'
+import { InlineInput } from '~test/helpers/input/InlineInput'
 
 const { options, exercise } = bootstrap({ exercise: 'two-fer' })
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "composite": true,
   "extends": "../tsconfig.json",
-  "exclude": ["./fixtures"],
   "compilerOptions": {
-    "noEmit": true,
+    "baseUrl": "./",
+    "paths": {
+      "~src/*": ["../src/*"],
+      "~test/*": ["./*"]
+    },
+    "noEmit": true
   },
-  "include": [
-    "./",
-    "../src"
-  ]
+  "include": ["./", "../src"],
+  "exclude": ["./fixtures"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
-    "paths": { "src/*": ["./src/*"] },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "paths": { "~src/*": ["./src/*"] },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                       /* Redirect output structure to the directory. */
-    "rootDirs": ["./src", "./"],              /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDirs": ["./"],              /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -38,8 +38,8 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    "paths": { "src/*": ["./src/*"] },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3147,6 +3147,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+module-alias@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.0.tgz#a2e32275381642252bf0c51405f7a09a367479b5"
+  integrity sha512-O4bbvlZkHj2LUQhieQWWCr486ddc8X+WwRqi3QGnFKfknaxdHTOB7+xRgeyWHc6arpjgtT5SLLMMTFwUM3/x5w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Adds module alias in typescript for nice resolution using root paths instead of relative paths, add the mapper for jest and add the runtime mapping from src to dist for... runtime.