### PR TITLE
Extract error reporting

### DIFF
--- a/src/errors/handler.ts
+++ b/src/errors/handler.ts
@@ -1,0 +1,31 @@
+import { GENERIC_FAILURE } from "./codes";
+
+export function registerExceptionHandler() {
+  process.on('uncaughtException', reportException)
+}
+
+function reportException<T extends Error & { message: string, code?: number }>(err: T): void
+function reportException<T extends Error & { message: string, code?: number }>(err: T | string): void {
+
+  if (typeof err === 'string') {
+    return reportException({ message: err, code: GENERIC_FAILURE, stack: undefined, name: 'UnknownError' })
+  }
+
+  const errorMessage = `
+An uncaughtException occurred (code: ${err.code || GENERIC_FAILURE}).
+
+Error Data:
+${JSON.stringify(err)}
+
+Stacktrace:
+${err.stack ? err.stack : '<no stack>'}
+  `.trim()
+
+  console.error()
+
+  // Write error to stderr as well
+  process.stderr.write(errorMessage)
+
+  // Exit with non-zero status
+  process.exit('code' in err ? err.code : GENERIC_FAILURE)
+}

--- a/src/utils/bootstrap.ts
+++ b/src/utils/bootstrap.ts
@@ -1,8 +1,8 @@
-import { ExecutionOptionsImpl } from './execution_options'
-import { Logger, setProcessLogger as setGlobalLogger } from '../utils/logger'
-import { DirectoryInput } from '../input/DirectoryInput';
-import { GENERIC_FAILURE } from '../errors/codes';
-import { ExerciseImpl } from '../ExerciseImpl';
+import { registerExceptionHandler } from '~src/errors/handler';
+import { ExerciseImpl } from '~src/ExerciseImpl';
+import { DirectoryInput } from '~src/input/DirectoryInput';
+import { Logger, setProcessLogger as setGlobalLogger } from '~src/utils/logger';
+import { ExecutionOptionsImpl } from './execution_options';
 
 export interface BootstrapResult {
   exercise: Exercise
@@ -30,12 +30,7 @@ export class Bootstrap {
    */
   static call(): BootstrapResult {
 
-    process.on('uncaughtException', function<T extends Error & { code?: number }>(err: T) {
-      console.error(err)
-      process.stderr.write(err.message)
-
-      process.exit('code' in err ? err.code : GENERIC_FAILURE)
-    })
+    registerExceptionHandler()
 
     const options   = ExecutionOptionsImpl.create()
     const logger    = new Logger(options)


### PR DESCRIPTION
Makes sure the error does not show up as `[object Object]`