### PR TITLE
Capture parse errors

### DIFF
--- a/src/comments/shared.ts
+++ b/src/comments/shared.ts
@@ -67,3 +67,13 @@ most IDEs from highlighting that parameter if it's unused, which is actually a
 tool you probably want to keep in this case. Remove the underscore \`_\` from
 ${'parameter_name'} in order to fix this.
 `('javascript.generic.prefer_unprefixed_underscore_parameters')
+
+export const PARSE_ERROR = factory<'error' | 'details'>`
+There is something wrong with your submission, most likely a Syntax Error:
+
+Message: "${'error'}"
+
+\`\`\`
+${'details'}
+\`\`\`
+`('javascript.generic.parse_error')

--- a/src/errors/NoSourceError.ts
+++ b/src/errors/NoSourceError.ts
@@ -1,0 +1,10 @@
+import { SOURCE_MISSING_ERROR } from "./codes";
+
+export class NoSourceError extends Error {
+  code = SOURCE_MISSING_ERROR
+
+  constructor() {
+    super('No source file(s) found')
+    Error.captureStackTrace(this, this.constructor)
+  }
+}

--- a/src/errors/NoSourceError.ts
+++ b/src/errors/NoSourceError.ts
@@ -1,10 +1,12 @@
 import { SOURCE_MISSING_ERROR } from "./codes";
 
 export class NoSourceError extends Error {
-  code = SOURCE_MISSING_ERROR
+  public readonly code: typeof SOURCE_MISSING_ERROR;
 
   constructor() {
     super('No source file(s) found')
     Error.captureStackTrace(this, this.constructor)
+
+    this.code = SOURCE_MISSING_ERROR
   }
 }

--- a/src/errors/ParserError.ts
+++ b/src/errors/ParserError.ts
@@ -1,7 +1,7 @@
 import { SOURCE_PARSE_ERROR } from "./codes";
 
 export class ParserError extends Error {
-  code = SOURCE_PARSE_ERROR
+  public readonly code: typeof SOURCE_PARSE_ERROR;
 
   constructor(public readonly original: Error) {
     super(`
@@ -12,5 +12,6 @@ ${original.message}
     `.trim())
 
     Error.captureStackTrace(this, this.constructor)
+    this.code = SOURCE_PARSE_ERROR
   }
 }

--- a/src/errors/ParserError.ts
+++ b/src/errors/ParserError.ts
@@ -1,0 +1,16 @@
+import { SOURCE_PARSE_ERROR } from "./codes";
+
+export class ParserError extends Error {
+  code = SOURCE_PARSE_ERROR
+
+  constructor(public readonly original: Error) {
+    super(`
+Could not parse the source; most likely due to a syntax error.
+
+Original error:
+${original.message}
+    `.trim())
+
+    Error.captureStackTrace(this, this.constructor)
+  }
+}

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -1,1 +1,3 @@
 export const GENERIC_FAILURE = -1
+export const SOURCE_MISSING_ERROR = 3
+export const SOURCE_PARSE_ERROR = 4

--- a/src/parsers/AstParser.ts
+++ b/src/parsers/AstParser.ts
@@ -1,4 +1,6 @@
 import { parse as parseToTree, TSESTree, TSESTreeOptions } from "@typescript-eslint/typescript-estree";
+import { NoSourceError } from '~src/errors/NoSourceError';
+import { ParserError } from "~src/errors/ParserError";
 import { getProcessLogger } from "~src/utils/logger";
 
 type Program = TSESTree.Program
@@ -21,7 +23,15 @@ export class AstParser {
     logger.log(`=> inputs: ${sources.length}`)
     sources.forEach(source => logger.log(`\n${source}\n`))
 
-    return sources.map(source => new ParsedSource(parseToTree(source, this.options), source))
+    if (sources.length === 0) {
+      throw new NoSourceError()
+    }
+
+    try {
+      return sources.map(source => new ParsedSource(parseToTree(source, this.options), source))
+    } catch(error) {
+      throw new ParserError(error)
+    }
   }
 }
 


### PR DESCRIPTION
Instead of blowing up the analyzer,

- Capture parse errors as `disapprove` and forward the syntax error
- Capture source (file missing) errors as `redirect`. This probably needs mentor interaction to help a hand, for now.

Increases the number of fixtures the analyzer can parse (`two-fer` up to 499, `resistor-color` up to 500).