### PR TITLE
Two-fer: conditional flow in one-line function

### DIFF
--- a/src/analyzers/AnalyzerImpl.ts
+++ b/src/analyzers/AnalyzerImpl.ts
@@ -25,7 +25,7 @@ export abstract class AnalyzerImpl implements Analyzer {
    * Runs the analyzer
    *
    * This is defined as a property instead of a method, so that it can not be
-   * overriddden in a subclass. Subclasses should override @see execute instead.
+   * overridden in a subclass. Subclasses should override @see execute instead.
    *
    * @returns The promise that resolves the analyzer output.
    *

--- a/src/analyzers/two-fer/index.ts
+++ b/src/analyzers/two-fer/index.ts
@@ -191,15 +191,16 @@ export class TwoFerAnalyzer extends AnalyzerImpl {
   }
 
   private checkForOptimalSolutions(): void | never {
-    // The optional solution looks like this:
+    // The optimal solution looks like this:
     //
     // export function twoFer(name = 'you') {
     //   return "One for #{name}, one for me."
     // }
     //
     // The default argument must be 'you', and it must just be a single
-    // statement using interpolation. Other solutions might be approved but this
-    // is the only one that we would approve without comment.
+    // statement using interpolation, without any if statements or ternary
+    // operators. Other solutions might be approved but this is the only
+    // one that we would approve without comment.
     //
     // NOTE: the current tests are incorrect and want you to do name || 'you'
 
@@ -231,7 +232,7 @@ export class TwoFerAnalyzer extends AnalyzerImpl {
 
   private checkForApprovableSolutions(): void | never {
     // If we don't have a correct default argument or a one line
-    // solution then let's just get out of here.
+    // solution, then let's just get out of here.
     if (!this.isOneLineSolution()) {
       return
     }
@@ -428,6 +429,15 @@ export class TwoFerAnalyzer extends AnalyzerImpl {
   }
 
   private isOneLineSolution(): boolean {
+    // A one-line solution will never have any conditional expressions
+    // (ternary operators) or if statements.
+    const conditionalExpressions = extractAll<ConditionalExpression>(this.mainMethod!, AST_NODE_TYPES.ConditionalExpression)
+    const ifStatements = extractAll<IfStatement>(this.mainMethod!, AST_NODE_TYPES.IfStatement)
+
+    if (conditionalExpressions.length !== 0 || ifStatements.length !== 0) {
+      return false
+    }
+
     // Maximum body count may be 2 (3 - 1)
     //
     // 1: export function twoFer(name = 'you') {

--- a/src/analyzers/two-fer/index.ts
+++ b/src/analyzers/two-fer/index.ts
@@ -440,7 +440,7 @@ export class TwoFerAnalyzer extends AnalyzerImpl {
     //
     const body = this.mainMethod!.body!
 
-    // This trick actually looks to the inner exppresion instead of the entire
+    // This trick actually looks to the inner expression instead of the entire
     // function in order to allow for comments inside the body.
     const { loc: { start: { line: lineStart }, end: { line: lineEnd } } } =
          body.type === AST_NODE_TYPES.BlockStatement

--- a/test/analyzers/two-fer/__snapshots__/snapshot.ts.snap
+++ b/test/analyzers/two-fer/__snapshots__/snapshot.ts.snap
@@ -7,13 +7,6 @@ AnalyzerOutput {
 }
 `;
 
-exports[`When running analysis on two-fer fixtures and expecting it to approve matches two-fer/118's output: output 1`] = `
-AnalyzerOutput {
-  "comments": Array [],
-  "status": "approve",
-}
-`;
-
 exports[`When running analysis on two-fer fixtures and expecting it to approve matches two-fer/129's output: output 1`] = `
 AnalyzerOutput {
   "comments": Array [],
@@ -22,13 +15,6 @@ AnalyzerOutput {
 `;
 
 exports[`When running analysis on two-fer fixtures and expecting it to approve matches two-fer/139's output: output 1`] = `
-AnalyzerOutput {
-  "comments": Array [],
-  "status": "approve",
-}
-`;
-
-exports[`When running analysis on two-fer fixtures and expecting it to approve matches two-fer/313's output: output 1`] = `
 AnalyzerOutput {
   "comments": Array [],
   "status": "approve",
@@ -263,15 +249,14 @@ exports[`When running analysis on two-fer fixtures and expecting it to disapprov
 AnalyzerOutput {
   "comments": Array [
     CommentImpl {
-      "externalTemplate": "javascript.two-fer.optimise_explicity_default_value",
-      "message": "Instead of relying on %{maybe_undefined_expression} being \\"undefined\\" when
-no value is passed in, you could set the default value of 'name' to
-'you'.",
-      "template": "Instead of relying on %{maybe_undefined_expression} being \\"undefined\\" when
-no value is passed in, you could set the default value of '%{parameter}' to
-'you'.",
+      "externalTemplate": "javascript.two-fer.optimise_default_value",
+      "message": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of name to 'you' to avoid this conditional.",
+      "template": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of %{parameter} to 'you' to avoid this conditional.",
       "variables": Object {
-        "maybe-undefined-expression": "name",
         "parameter": "name",
       },
     },
@@ -471,6 +456,46 @@ of %{parameter} to 'you' to avoid this conditional.",
 }
 `;
 
+exports[`When running analysis on two-fer fixtures and expecting it to disapprove matches two-fer/118's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.two-fer.optimise_default_value",
+      "message": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of name to 'you' to avoid this conditional.",
+      "template": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of %{parameter} to 'you' to avoid this conditional.",
+      "variables": Object {
+        "parameter": "name",
+      },
+    },
+  ],
+  "status": "disapprove",
+}
+`;
+
+exports[`When running analysis on two-fer fixtures and expecting it to disapprove matches two-fer/120's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.two-fer.optimise_default_value",
+      "message": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of name to 'you' to avoid this conditional.",
+      "template": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of %{parameter} to 'you' to avoid this conditional.",
+      "variables": Object {
+        "parameter": "name",
+      },
+    },
+  ],
+  "status": "disapprove",
+}
+`;
+
 exports[`When running analysis on two-fer fixtures and expecting it to disapprove matches two-fer/121's output: output 1`] = `
 AnalyzerOutput {
   "comments": Array [
@@ -531,6 +556,26 @@ of %{parameter} to 'you' to avoid this conditional.",
 }
 `;
 
+exports[`When running analysis on two-fer fixtures and expecting it to disapprove matches two-fer/313's output: output 1`] = `
+AnalyzerOutput {
+  "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.two-fer.optimise_default_value",
+      "message": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of name to 'you' to avoid this conditional.",
+      "template": "You currently use a conditional to branch in case there is no value passed into
+\`twoFer\`. Instead you could set the [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+of %{parameter} to 'you' to avoid this conditional.",
+      "variables": Object {
+        "parameter": "name",
+      },
+    },
+  ],
+  "status": "disapprove",
+}
+`;
+
 exports[`When running analysis on two-fer fixtures and expecting it to refer to mentor matches two-fer/0's output: output 1`] = `
 AnalyzerOutput {
   "comments": Array [],
@@ -569,20 +614,6 @@ AnalyzerOutput {
 exports[`When running analysis on two-fer fixtures and expecting it to refer to mentor matches two-fer/119's output: output 1`] = `
 AnalyzerOutput {
   "comments": Array [],
-  "status": "refer_to_mentor",
-}
-`;
-
-exports[`When running analysis on two-fer fixtures and expecting it to refer to mentor matches two-fer/120's output: output 1`] = `
-AnalyzerOutput {
-  "comments": Array [
-    CommentImpl {
-      "externalTemplate": "javascript.two-fer.redirect_incorrect_string_template",
-      "message": "The string template looks incorrect. Expected a template with 3 components.",
-      "template": "The string template looks incorrect. Expected a template with 3 components.",
-      "variables": Object {},
-    },
-  ],
   "status": "refer_to_mentor",
 }
 `;

--- a/test/analyzers/two-fer/snapshot.ts
+++ b/test/analyzers/two-fer/snapshot.ts
@@ -8,14 +8,15 @@ const snapshotTestsGenerator = makeTestGenerator(
 
 describe('When running analysis on two-fer fixtures', () => {
   snapshotTestsGenerator('approve', [
-    118, 129, 139, 313, 400, 493, 70
+    129, 139, 400, 493, 70
   ])
   snapshotTestsGenerator('disapprove', [
     1, 10, 100, 101, 102, 104, 105, 107, 109, 11,
-    110, 111, 112, 114, 115, 116, 12, 121, 123, 124
+    110, 111, 112, 114, 115, 116, 12, 121, 123, 124,
+    118, 120, 313
   ])
   snapshotTestsGenerator('refer_to_mentor', [
-    0, 103, 106, 108, 113, 119, 120, 122, 133, 138,
+    0, 103, 106, 108, 113, 119, 122, 133, 138,
     143, 147, 148, 166, 171, 175, 181, 183, 192, 194
   ])
 })


### PR DESCRIPTION
Fixes #21 

A two-fer solution containing any ternary operators or if statements is no longer erroneously considered to be an optimal "one-line" solution.

Tests that were updated:
* 105 used to disapprove with `javascript.two-fer.optimise_explicity_default_value`
```javascript
export const twoFer = (name) => `One for ${name ? name : 'you'}, one for me.`;  // 105
```
* 118 used to approve with no comment
```javascript
export const twoFer = (name = 'you') => `One for ${name.length ? name : 'you'}, one for me.`;  // 118
```
* 120 used to redirect with `javascript.two-fer.redirect_incorrect_string_template`
```javascript
export function twoFer(name = 'you') {
	return name === '' ? `One for you, one for me.` : `One for ${name}, one for me.`;  // 120
}
```
* 313 used to approve with no comment
```javascript
export const twoFer = (name = 'you') => (name === '' ? 'One for you, one for me.' : `One for ${name}, one for me.`);  // 313
```

Each of these fixtures is now disapproved with `javascript.two-fer.optimise_default_value`