### PR TITLE
Add exercism/maintainers-admin team as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @exercism/maintainers-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @exercism/maintainers-admin
+* @sleeplessbyte
+.github/CODEOWNERS @exercism/maintainers-admin


### PR DESCRIPTION
The tooling is essential to the functioning of v3. To help ensure that any changes work well with the v3 website, the exercism/maintainers-admin team is added as a codeowner.

See https://github.com/exercism/exercism/issues/5400