### PR TITLE
Automatically push Docker image to Amazon ECR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to Amazon ECR
+
+env:
+  aws_region: eu-west-2
+  ecr_repository: ${{ github.event.repository.name }}
+  dockerfile: "Dockerfile"
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    name: Upload image to ECR
+    runs-on: ubuntu-latest
+    steps:
+      ###############
+      ###############
+      # Setup Steps #
+      ###############
+      ###############
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: satackey/action-docker-layer-caching@v0.0.5
+        continue-on-error: true
+        with:
+          concurrency: 30
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.aws_region }}
+
+      - name: Login to Amazon ECR
+        id: login_to_ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      ###################
+      ###################
+      # Build the image #
+      ###################
+      ###################
+      - name: Build and Push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login_to_ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ env.ecr_repository }}
+          IMAGE_TAG: "${{ github.sha }}"
+          DOCKERFILE: ${{ env.dockerfile }}
+        run: |
+          # Build a docker container and push it to ECR
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f $DOCKERFILE .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          
+          # Retag this as the production tag to deploy it
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:production
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:production


### PR DESCRIPTION
The v3 website uses Docker images from Amazon ECR for all the tooling.
Each tooling repo should have a workflow to automatically push to Amazon ECR whenever something is merged to master.

This PR adds a GitHub Actions workflow to automatically build and push a new Docker image whenever something is merged to master.

See https://github.com/exercism/v3/issues/2728
