### PR TITLE
two-fer: Allow coalesce

### DIFF
--- a/test/analyzers/two-fer/issue68.ts
+++ b/test/analyzers/two-fer/issue68.ts
@@ -1,0 +1,18 @@
+import { TwoFerAnalyzer } from '~src/analyzers/practice/two-fer'
+import { makeAnalyze } from '~test/helpers/smoke'
+
+const analyze = makeAnalyze(() => new TwoFerAnalyzer())
+
+describe('When running analysis on two-fer', () => {
+  it('does not generate actionable comments when using coalesce', async () => {
+    const solutionContent = `
+    export const twoFer = (name) => {
+      return \`One for \${name ?? 'you'}, one for me.\`
+    }
+    `.trim()
+
+    const output = await analyze(solutionContent)
+
+    expect(output.comments.length).toBe(0)
+  })
+})


### PR DESCRIPTION
Fixes #68

Because we no longer disapprove, this issue was fixed. The test case added makes sure we don't add code that breaks it later.