### PR TITLE
Link fixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,5 @@ If the comment factories are kept in-sync with `website-copy`, it will be the ex
 [cli]: https://github.com/exercism/cli
 [git-static-analysis]: https://github.com/exercism/javascript-lib-static-analysis
 [git-javascript]: https://github.com/exercism/javascript
+[file-bin]: https://github.com/exercism/javascript-analyzer/bin
+[file-execution-options]: https://github.com/exercism/javascript-analyzer/src/utils/execution_options.ts


### PR DESCRIPTION
I saw a couple places where it looked like links where wanted `bin/*` and `execution_options.ts`.