### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Use Node.js LTS (16.x)
         uses: actions/setup-node@v1
         with:
@@ -32,7 +32,7 @@ jobs:
         node-version: [14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/pr.ci.js.yml
+++ b/.github/workflows/pr.ci.js.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Use Node.js LTS (16.x)
         uses: actions/setup-node@v1
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/verify-code-formatting.yml
+++ b/.github/workflows/verify-code-formatting.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Use Node.js LTS (16.x)
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.