### PR TITLE
[Resistor Duo analyzer (#127)] Add feedback to extract the constant to the top level if defined locally

### DIFF
--- a/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
+++ b/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
@@ -515,7 +515,7 @@ class Entry {
     }
 
     if (!constant) {
-      const issue = this.checkForShouldDefineTopLevelConstantIssue()
+      const issue = this.hasConstantDefinedInBody()
       if (issue instanceof ShouldDefineTopLevelConstant) {
         logger.log('~> found a constant that was not declared at the top level')
         this.lastIssue_ = issue
@@ -1127,9 +1127,7 @@ class Entry {
     return false
   }
 
-  private checkForShouldDefineTopLevelConstantIssue():
-    | ShouldDefineTopLevelConstant
-    | undefined {
+  private hasConstantDefinedInBody(): ShouldDefineTopLevelConstant | undefined {
     const localConstants = extractVariables(this.body).filter(
       (constant) =>
         constant.init?.type === AST_NODE_TYPES.ArrayExpression ||

--- a/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
+++ b/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
@@ -21,8 +21,7 @@ import {
   SpecificObjectPropertyCall,
   SpecificPropertyCall,
 } from '@exercism/static-analysis'
-import { TSESTree } from '@typescript-eslint/typescript-estree'
-import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree'
 import { Source } from '~src/analyzers/SourceImpl'
 import { parameterName } from '~src/analyzers/utils/extract_parameter'
 import { assertNamedExport } from '~src/asserts/assert_named_export'

--- a/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
+++ b/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
@@ -21,7 +21,8 @@ import {
   SpecificObjectPropertyCall,
   SpecificPropertyCall,
 } from '@exercism/static-analysis'
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree'
+import type { TSESTree } from '@typescript-eslint/typescript-estree'
+import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree'
 import { Source } from '~src/analyzers/SourceImpl'
 import { parameterName } from '~src/analyzers/utils/extract_parameter'
 import { assertNamedExport } from '~src/asserts/assert_named_export'
@@ -1131,8 +1132,8 @@ class Entry {
     | undefined {
     const localConstants = extractVariables(this.body).filter(
       (constant) =>
-        constant.init?.type === TSESTree.AST_NODE_TYPES.ArrayExpression ||
-        constant.init?.type === TSESTree.AST_NODE_TYPES.ObjectExpression
+        constant.init?.type === AST_NODE_TYPES.ArrayExpression ||
+        constant.init?.type === AST_NODE_TYPES.ObjectExpression
     )
     if (localConstants.length) {
       const nameOfFirstConstant = localConstants[0].name || 'COLORS'

--- a/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
+++ b/src/analyzers/practice/resistor-color-duo/ResistorColorDuoSolution.ts
@@ -1148,7 +1148,6 @@ export class ResistorColorDuoSolution {
   private mainExport: ExtractedExport
   private fileConstants: ProgramConstants
   private mainConstant: Constant | undefined
-  private _hasLocalConstant = false
 
   constructor(public readonly program: Program, source: string) {
     this.source = new Source(source)

--- a/src/analyzers/practice/resistor-color-duo/index.ts
+++ b/src/analyzers/practice/resistor-color-duo/index.ts
@@ -21,7 +21,6 @@ import {
   MethodNotFound,
   MissingExpectedCall,
   ResistorColorDuoSolution,
-  ShouldDefineTopLevelConstant,
   UnexpectedCallFound,
 } from './ResistorColorDuoSolution'
 
@@ -291,13 +290,6 @@ export class ResistorColorDuoAnalyzer extends IsolatedAnalyzerImpl {
       }
 
       output.disapprove()
-    } else if (lastIssue instanceof ShouldDefineTopLevelConstant) {
-      output.add(
-        PREFER_EXTRACTED_TOP_LEVEL_CONSTANT({
-          name: lastIssue.name,
-          value: lastIssue.value,
-        })
-      )
     } else {
       this.logger.error(
         'The analyzer did not handle the issue: ' + JSON.stringify(lastIssue)
@@ -310,6 +302,15 @@ export class ResistorColorDuoAnalyzer extends IsolatedAnalyzerImpl {
     solution: ResistorColorDuoSolution,
     output: WritableOutput
   ): void | never {
+    if (solution.shouldExtractTopLevelConstant) {
+      output.add(
+        PREFER_EXTRACTED_TOP_LEVEL_CONSTANT({
+          name: solution.entry.nameOfConstantDefinedInBody,
+          value: '...',
+        })
+      )
+    }
+
     if (solution || output) {
       return
     }

--- a/src/analyzers/practice/resistor-color-duo/index.ts
+++ b/src/analyzers/practice/resistor-color-duo/index.ts
@@ -21,6 +21,7 @@ import {
   MethodNotFound,
   MissingExpectedCall,
   ResistorColorDuoSolution,
+  ShouldDefineTopLevelConstant,
   UnexpectedCallFound,
 } from './ResistorColorDuoSolution'
 
@@ -117,6 +118,21 @@ const ISSUE_UNEXPECTED_CALL = factory<'unexpected' | 'expected'>`
 📕 Found \`${'unexpected'}\`, expected \`${'expected'}\`.
 `(
   'javascript.resistor-color-duo.expected_different_call',
+  CommentType.Actionable
+)
+
+const PREFER_EXTRACTED_TOP_LEVEL_CONSTANT = factory<'value' | 'name'>`
+Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const ${'name'} = ${'value'}
+
+export const decodedValue = (...)
+\`\`\`
+`(
+  'javascript.resistor-color-duo.prefer_extracted_top_level_constant',
   CommentType.Actionable
 )
 
@@ -275,6 +291,13 @@ export class ResistorColorDuoAnalyzer extends IsolatedAnalyzerImpl {
       }
 
       output.disapprove()
+    } else if (lastIssue instanceof ShouldDefineTopLevelConstant) {
+      output.add(
+        PREFER_EXTRACTED_TOP_LEVEL_CONSTANT({
+          name: lastIssue.name,
+          value: lastIssue.value,
+        })
+      )
     } else {
       this.logger.error(
         'The analyzer did not handle the issue: ' + JSON.stringify(lastIssue)

--- a/src/analyzers/practice/resistor-color-duo/index.ts
+++ b/src/analyzers/practice/resistor-color-duo/index.ts
@@ -120,15 +120,17 @@ const ISSUE_UNEXPECTED_CALL = factory<'unexpected' | 'expected'>`
   CommentType.Actionable
 )
 
-const PREFER_EXTRACTED_TOP_LEVEL_CONSTANT = factory<'value' | 'name'>`
-Instead of defining the constant _inside_ the function, consider extracting it
+const PREFER_EXTRACTED_TOP_LEVEL_CONSTANT = factory<
+  'value' | 'name' | 'method.signature'
+>`
+📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const ${'name'} = ${'value'}
 
-export const decodedValue = (...)
+export ${'method.signature'}
 \`\`\`
 `(
   'javascript.resistor-color-duo.prefer_extracted_top_level_constant',
@@ -307,6 +309,7 @@ export class ResistorColorDuoAnalyzer extends IsolatedAnalyzerImpl {
         PREFER_EXTRACTED_TOP_LEVEL_CONSTANT({
           name: solution.entry.nameOfConstantDefinedInBody,
           value: '...',
+          'method.signature': solution.entry.signature,
         })
       )
     }

--- a/test/analyzers/resistor-color-duo/__snapshots__/snapshot.ts.snap
+++ b/test/analyzers/resistor-color-duo/__snapshots__/snapshot.ts.snap
@@ -87,6 +87,32 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const colors = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "colors",
+        "value": "...",
+      },
+    },
+    CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
 strict than the \`parseXXX\` family and applies in this exercise.",
@@ -588,6 +614,32 @@ call\\" with a named call, that can be documented individually.",
 exports[`When running analysis on resistor-color-duo fixtures and expecting matches resistor-color-duo/105's output: output 1`] = `
 IsolatedAnalyzerOutput {
   "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const COLORS = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "COLORS",
+        "value": "...",
+      },
+    },
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
@@ -1187,24 +1239,59 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
-      "externalTemplate": "javascript.resistor-color-duo.must_use_a_helper",
-      "message": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
-      "template": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+\`\`\`javascript
+const COLORS = ...
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
       "type": "actionable",
+      "variables": Object {
+        "name": "COLORS",
+        "value": "...",
+      },
+    },
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
+      "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
+strict than the \`parseXXX\` family and applies in this exercise.",
+      "template": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
+strict than the \`parseXXX\` family and applies in this exercise.",
+      "type": "actionable",
+      "variables": Object {},
+    },
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.limit_number_of_colors",
+      "message": "💬 Limit the number of input colors that are processed. If more than two colors
+are passed in, only the first two colors should be used to calculate the total
+\`colorCode\` value.
+
+📕 (At least) one test case inputs three colors instead of two. If the student
+has not accounted for this, they might need to update their solution. Help them
+find the button to update. The tests won't pass without limiting the number of
+colors.",
+      "template": "💬 Limit the number of input colors that are processed. If more than two colors
+are passed in, only the first two colors should be used to calculate the total
+\`colorCode\` value.
+
+📕 (At least) one test case inputs three colors instead of two. If the student
+has not accounted for this, they might need to update their solution. Help them
+find the button to update. The tests won't pass without limiting the number of
+colors.",
+      "type": "essential",
       "variables": Object {},
     },
   ],
@@ -1274,6 +1361,32 @@ The tests won't pass without it.",
 exports[`When running analysis on resistor-color-duo fixtures and expecting matches resistor-color-duo/143's output: output 1`] = `
 IsolatedAnalyzerOutput {
   "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const CODES = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "CODES",
+        "value": "...",
+      },
+    },
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.use_array_comprehensions",
       "message": "💬 Replace \`.forEach(...)\` with a comprehension such as \`map\`.",
@@ -1821,6 +1934,32 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const COLORS = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "COLORS",
+        "value": "...",
+      },
+    },
+    CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
 strict than the \`parseXXX\` family and applies in this exercise.",
@@ -1872,34 +2011,64 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
-      "externalTemplate": "javascript.resistor-color-duo.must_use_a_helper",
-      "message": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
-      "template": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+\`\`\`javascript
+const colorMap = ...
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
       "type": "actionable",
-      "variables": Object {},
+      "variables": Object {
+        "name": "colorMap",
+        "value": "...",
+      },
     },
   ],
-  "summary": undefined,
 }
 `;
 
 exports[`When running analysis on resistor-color-duo fixtures and expecting matches resistor-color-duo/183's output: output 1`] = `
 IsolatedAnalyzerOutput {
   "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const colors = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "colors",
+        "value": "...",
+      },
+    },
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
@@ -1981,24 +2150,59 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
-      "externalTemplate": "javascript.resistor-color-duo.must_use_a_helper",
-      "message": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
-      "template": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+\`\`\`javascript
+const bandColors = ...
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
       "type": "actionable",
+      "variables": Object {
+        "name": "bandColors",
+        "value": "...",
+      },
+    },
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
+      "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
+strict than the \`parseXXX\` family and applies in this exercise.",
+      "template": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
+strict than the \`parseXXX\` family and applies in this exercise.",
+      "type": "actionable",
+      "variables": Object {},
+    },
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.limit_number_of_colors",
+      "message": "💬 Limit the number of input colors that are processed. If more than two colors
+are passed in, only the first two colors should be used to calculate the total
+\`colorCode\` value.
+
+📕 (At least) one test case inputs three colors instead of two. If the student
+has not accounted for this, they might need to update their solution. Help them
+find the button to update. The tests won't pass without limiting the number of
+colors.",
+      "template": "💬 Limit the number of input colors that are processed. If more than two colors
+are passed in, only the first two colors should be used to calculate the total
+\`colorCode\` value.
+
+📕 (At least) one test case inputs three colors instead of two. If the student
+has not accounted for this, they might need to update their solution. Help them
+find the button to update. The tests won't pass without limiting the number of
+colors.",
+      "type": "essential",
       "variables": Object {},
     },
   ],
@@ -2263,6 +2467,32 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const COLORS = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "COLORS",
+        "value": "...",
+      },
+    },
+    CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
 strict than the \`parseXXX\` family and applies in this exercise.",
@@ -2296,6 +2526,32 @@ strict than the \`parseXXX\` family and applies in this exercise.",
 exports[`When running analysis on resistor-color-duo fixtures and expecting matches resistor-color-duo/205's output: output 1`] = `
 IsolatedAnalyzerOutput {
   "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const COLORS = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "COLORS",
+        "value": "...",
+      },
+    },
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.use_array_comprehensions",
       "message": "💬 Replace \`for(...) { }\` with a comprehension such as \`map\`.",
@@ -2545,6 +2801,32 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const COLORS = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "COLORS",
+        "value": "...",
+      },
+    },
+    CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
 strict than the \`parseXXX\` family and applies in this exercise.",
@@ -2731,6 +3013,32 @@ IsolatedAnalyzerOutput {
 exports[`When running analysis on resistor-color-duo fixtures and expecting matches resistor-color-duo/235's output: output 1`] = `
 IsolatedAnalyzerOutput {
   "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const colors = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "colors",
+        "value": "...",
+      },
+    },
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more
@@ -3144,6 +3452,32 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const resistor = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "resistor",
+        "value": "...",
+      },
+    },
+    CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.use_array_comprehensions",
       "message": "💬 Replace \`.forEach(...)\` with a comprehension such as \`map\`.",
       "template": "💬 Replace \`%{current}\` with a comprehension such as \`map\`.",
@@ -3440,25 +3774,30 @@ exports[`When running analysis on resistor-color-duo fixtures and expecting matc
 IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
-      "externalTemplate": "javascript.resistor-color-duo.must_use_a_helper",
-      "message": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
-      "template": "📕 Mentor the student to add helper function and DRY-up this solution. The
-solution to \`resistor-color\` can be used as helper method here. When using an
-\`Array\` as colors source, in a years time, will the student recall why it's
-the _index_ in that array? When using an \`Object\`, what does the value mean?
-Re-using \`colorCode\` explains this in both cases.
+\`\`\`javascript
+const COLORS = ...
 
-💬 Using a helper method is good practice, because it replaces a cryptic \\"member
-call\\" with a named call, that can be documented individually.",
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
       "type": "actionable",
-      "variables": Object {},
+      "variables": Object {
+        "name": "COLORS",
+        "value": "...",
+      },
     },
   ],
   "summary": undefined,
@@ -3651,6 +3990,32 @@ strict than the \`parseXXX\` family and applies in this exercise.",
 exports[`When running analysis on resistor-color-duo fixtures and expecting matches resistor-color-duo/289's output: output 1`] = `
 IsolatedAnalyzerOutput {
   "comments": Array [
+    CommentImpl {
+      "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
+      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const array = ...
+
+export const decodedValue = (...)
+\`\`\`",
+      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+to the top-level. Constants, functions, and classes that are not \`export\`ed,
+are not accessible from outside the file.
+
+\`\`\`javascript
+const %{name} = %{value}
+
+export const decodedValue = (...)
+\`\`\`",
+      "type": "actionable",
+      "variables": Object {
+        "name": "array",
+        "value": "...",
+      },
+    },
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_number_over_parse",
       "message": "💬 Use \`Number(...)\` when the input is expected to be a number. It's more

--- a/test/analyzers/resistor-color-duo/__snapshots__/snapshot.ts.snap
+++ b/test/analyzers/resistor-color-duo/__snapshots__/snapshot.ts.snap
@@ -88,26 +88,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const colors = ...
 
-export const decodedValue = (...)
+export function decodedValue(input) ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "function decodedValue(input) ...",
         "name": "colors",
         "value": "...",
       },
@@ -616,26 +617,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const COLORS = ...
 
-export const decodedValue = (...)
+export const decodedValue = (resistorColors) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = (resistorColors) => ...",
         "name": "COLORS",
         "value": "...",
       },
@@ -1240,26 +1242,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const COLORS = ...
 
-export const decodedValue = (...)
+export const decodedValue = colorArray => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = colorArray => ...",
         "name": "COLORS",
         "value": "...",
       },
@@ -1363,26 +1366,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const CODES = ...
 
-export const decodedValue = (...)
+export const decodedValue = (colors) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = (colors) => ...",
         "name": "CODES",
         "value": "...",
       },
@@ -1935,26 +1939,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const COLORS = ...
 
-export const decodedValue = (...)
+export const decodedValue = (args) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = (args) => ...",
         "name": "COLORS",
         "value": "...",
       },
@@ -2012,26 +2017,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const colorMap = ...
 
-export const decodedValue = (...)
+export function decodedValue([first, second]) ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "function decodedValue([first, second]) ...",
         "name": "colorMap",
         "value": "...",
       },
@@ -2045,26 +2051,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const colors = ...
 
-export const decodedValue = (...)
+export const decodedValue = ([colorOne, colorTwo]) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = ([colorOne, colorTwo]) => ...",
         "name": "colors",
         "value": "...",
       },
@@ -2151,26 +2158,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const bandColors = ...
 
-export const decodedValue = (...)
+export function decodedValue (colors) ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "function decodedValue (colors) ...",
         "name": "bandColors",
         "value": "...",
       },
@@ -2468,26 +2476,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const COLORS = ...
 
-export const decodedValue = (...)
+export function decodedValue([color1, color2]) ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "function decodedValue([color1, color2]) ...",
         "name": "COLORS",
         "value": "...",
       },
@@ -2528,26 +2537,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const COLORS = ...
 
-export const decodedValue = (...)
+export const decodedValue = (arr) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = (arr) => ...",
         "name": "COLORS",
         "value": "...",
       },
@@ -2802,26 +2812,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const COLORS = ...
 
-export const decodedValue = (...)
+export const decodedValue = colors => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = colors => ...",
         "name": "COLORS",
         "value": "...",
       },
@@ -3015,26 +3026,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const colors = ...
 
-export const decodedValue = (...)
+export function decodedValue([color1, color2]) ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "function decodedValue([color1, color2]) ...",
         "name": "colors",
         "value": "...",
       },
@@ -3453,26 +3465,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const resistor = ...
 
-export const decodedValue = (...)
+export const decodedValue = (colorsArr) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = (colorsArr) => ...",
         "name": "resistor",
         "value": "...",
       },
@@ -3775,26 +3788,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const COLORS = ...
 
-export const decodedValue = (...)
+export const decodedValue = (colorArray) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = (colorArray) => ...",
         "name": "COLORS",
         "value": "...",
       },
@@ -3992,26 +4006,27 @@ IsolatedAnalyzerOutput {
   "comments": Array [
     CommentImpl {
       "externalTemplate": "javascript.resistor-color-duo.prefer_extracted_top_level_constant",
-      "message": "Instead of defining the constant _inside_ the function, consider extracting it
+      "message": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const array = ...
 
-export const decodedValue = (...)
+export const decodedValue = (colors) => ...
 \`\`\`",
-      "template": "Instead of defining the constant _inside_ the function, consider extracting it
+      "template": "📕 Instead of defining the constant _inside_ the function, consider extracting it
 to the top-level. Constants, functions, and classes that are not \`export\`ed,
 are not accessible from outside the file.
 
 \`\`\`javascript
 const %{name} = %{value}
 
-export const decodedValue = (...)
+export %{method.signature}
 \`\`\`",
       "type": "actionable",
       "variables": Object {
+        "method.signature": "const decodedValue = (colors) => ...",
         "name": "array",
         "value": "...",
       },


### PR DESCRIPTION
The goal of this PR is to address a subset of issue #127, namely adding the feedback to extract the constant to the top level when it was defined locally to the Resistor Color Duo analyzer.

### Context
The original issue posed two problems to solve:
1. Suppress the feedback to extract a helper method when an object was used as the constant.
2. Introduce a new feedback item that suggests extracting the constant to top level scope if it was defined locally.

This PR addresses (2), since it is an atomic piece of new functionality. After the resolution of this PR the state of the issue should be re-evaluated, since addressing (1) would, in my opinion, require a refactor, due to the entanglement of logic between the helper method feedback and the rest of the feedback, which should be weighed against the value gained.

### Main changes
- Added a new class (`ShouldDefineTopLevelConstant`) to denote the new kind of feedback.
- Added logic to instantiate this class and assign it to the `lastIssue_` member of the `Entry` class, such that it can be consumed in the `index.ts` file responsible for parsing the result of the Resistor Color Duo analyzer.
- Added a new comment factory to be used for this feedback. It closely resembles the `PREFER_EXTRACTED_TOP_LEVEL_CONSTANT ` factory defined in the `GigasecondSolution.ts` file. This copy will have to be added to the [`website_copy`](https://github.com/exercism/website-copy/tree/main/analyzer-comments/javascript) repo.
- Updated the snapshot tests to reflect the change.