### PR TITLE
two-fer: detect and block stub throw implementations

### DIFF
--- a/src/analyzers/practice/two-fer/index.ts
+++ b/src/analyzers/practice/two-fer/index.ts
@@ -101,6 +101,7 @@ export class TwoFerAnalyzer extends AnalyzerImpl {
 
     if (hasStubThrow(this.mainMethod)) {
       this.disapprove(REMOVE_STUB_THROW())
+      return
     }
 
     // Now we want to ensure that the method signature is sane and that it has

--- a/src/analyzers/utils/extract_main_method.ts
+++ b/src/analyzers/utils/extract_main_method.ts
@@ -114,26 +114,10 @@ function isStubThrowStatement(statement: TSESTree.Statement): boolean {
 export function hasStubThrow(fn: { body?: TSESTree.Node }): boolean {
   if (!fn.body || fn.body.type !== 'BlockStatement') return false
 
-  const statements = fn.body.body
-
-  // Case 1: single-line stub throw
-  if (statements.length === 1 && isStubThrowStatement(statements[0])) {
-    return true
-  }
-
-  // Case 2: unreachable stub throw after return
-  for (let i = 0; i < statements.length - 1; i++) {
-    const current = statements[i]
-    const next = statements[i + 1]
-
-    if (
-      current.type === 'ReturnStatement' &&
-      isStubThrowStatement(next)
-    ) {
-      return true
-    }
-  }
-
-  return false
+  return fn.body.body.some(
+    (statement) =>
+      statement.type === 'ThrowStatement' &&
+      isStubThrowStatement(statement)
+  )
 }
 

--- a/src/analyzers/utils/extract_main_method.ts
+++ b/src/analyzers/utils/extract_main_method.ts
@@ -80,7 +80,6 @@ export function extractMainMethod<T extends string = string>(
   return undefined
 }
 
-
 function isNewExpression(node: unknown): node is TSESTree.NewExpression {
   return (
     typeof node === 'object' &&
@@ -110,14 +109,11 @@ function isStubThrowStatement(statement: TSESTree.Statement): boolean {
   )
 }
 
-
 export function hasStubThrow(fn: { body?: TSESTree.Node }): boolean {
   if (!fn.body || fn.body.type !== 'BlockStatement') return false
 
   return fn.body.body.some(
     (statement) =>
-      statement.type === 'ThrowStatement' &&
-      isStubThrowStatement(statement)
+      statement.type === 'ThrowStatement' && isStubThrowStatement(statement)
   )
 }
-

--- a/src/comments/remove_stub_throw.ts
+++ b/src/comments/remove_stub_throw.ts
@@ -1,0 +1,5 @@
+import { factory, CommentType } from '~src/comments/comment'
+
+export const REMOVE_STUB_THROW = factory`
+Remove this placeholder throw statement. It is dead code.
+`('javascript.general.remove_stub_throw', CommentType.Actionable)

--- a/src/comments/remove_stub_throw.ts
+++ b/src/comments/remove_stub_throw.ts
@@ -2,4 +2,4 @@ import { factory, CommentType } from '~src/comments/comment'
 
 export const REMOVE_STUB_THROW = factory`
 Remove this placeholder throw statement. It is dead code.
-`('javascript.general.remove_stub_throw', CommentType.Actionable)
+`('javascript.general.remove_stub_throw', CommentType.Essential)

--- a/test/analyzers/two-fer/stub-throw.ts
+++ b/test/analyzers/two-fer/stub-throw.ts
@@ -1,0 +1,43 @@
+import { TwoFerAnalyzer } from '~src/analyzers/practice/two-fer'
+import { makeAnalyze } from '~test/helpers/smoke'
+
+const analyze = makeAnalyze(() => new TwoFerAnalyzer())
+
+describe('two-fer stub throw detection', () => {
+  it('blocks canonical exercism stub throw', async () => {
+    const solution = `
+      export function twoFer(name = 'you') {
+        return 'One for you, one for me.'
+        throw new Error('Remove this line and implement the function');
+      }
+    `.trim()
+
+    const output = await analyze(solution)
+
+    const stub = output.comments.find(
+      (c) => c.externalTemplate === 'javascript.general.remove_stub_throw'
+    )
+
+    expect(stub).toBeDefined()
+    expect(stub?.type).toBe('essential')
+  })
+
+  it('does not block normal error throws', async () => {
+    const solution = `
+      export function twoFer(name = 'you') {
+        if (name === 'bad') {
+          throw new Error('Invalid name');
+        }
+        return \`One for \${name}, one for me.\`
+      }
+    `.trim()
+
+    const output = await analyze(solution)
+
+    const stub = output.comments.find(
+      (c) => c.externalTemplate === 'javascript.general.remove_stub_throw'
+    )
+
+    expect(stub).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Summary
Detects placeholder implementations in the two-fer exercise that throw
`new Error("Please implement …")` and blocks them.

### Details
- Adds a reusable `hasStubThrow` utility to detect stub throw patterns
- Introduces an actionable comment to tell students to remove dead stub code
- Integrates the check into the two-fer analyzer flow
- All existing tests pass

### Motivation
Stub throw implementations are not valid solutions but were previously allowed.
This change ensures they are caught early and feedback is clear.
